### PR TITLE
Add VRM avatar support with lip sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
   "dependencies": {
     "@heroicons/vue": "^2.2.0",
     "pinia": "^3.0.3",
-    "vue": "^3.5.16"
+    "vue": "^3.5.16",
+    "three": "^0.165.0",
+    "@pixiv/three-vrm": "^2.0.0"
   }
 }

--- a/src/frontend/components/AvatarView.vue
+++ b/src/frontend/components/AvatarView.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted, watch } from 'vue';
+import { useInterviewStore } from '../stores/interview';
+import { AvatarController } from '../vrm/AvatarController';
+
+const canvasRef = ref<HTMLCanvasElement | null>(null);
+let controller: AvatarController | null = null;
+const interviewStore = useInterviewStore();
+
+function init() {
+  if (canvasRef.value) {
+    controller = new AvatarController(canvasRef.value);
+    // デモ用のモデルURL。実環境では任意のVRMに変更してね！
+    controller.load('https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@2.0.0/examples/models/AliciaSolid.vrm');
+  }
+}
+
+onMounted(() => {
+  init();
+});
+
+onUnmounted(() => {
+  controller?.dispose();
+});
+
+watch(
+  () => interviewStore.audioStream,
+  (stream) => {
+    if (stream) {
+      controller?.startLipSync(stream);
+    } else {
+      controller?.stopLipSync();
+    }
+  }
+);
+</script>
+
+<template>
+  <canvas ref="canvasRef" class="w-full h-72 md:h-full"></canvas>
+</template>

--- a/src/frontend/components/InterviewWorkspace.vue
+++ b/src/frontend/components/InterviewWorkspace.vue
@@ -2,6 +2,7 @@
 import InterviewControls from './InterviewControls.vue';
 import TranscriptionPanel from './TranscriptionPanel.vue';
 import FeedbackPanel from './FeedbackPanel.vue';
+import AvatarView from './AvatarView.vue';
 import { useInterviewStore } from '../stores/interview';
 import { onMounted } from 'vue';
 
@@ -23,7 +24,7 @@ onMounted(() => {
           <InterviewControls />
         </div>
       </div>
-      <div v-else class="grid grid-cols-1 md:grid-cols-2 gap-6 h-[calc(100vh-200px)]">
+      <div v-else class="grid grid-cols-1 md:grid-cols-3 gap-6 h-[calc(100vh-200px)]">
         <div>
           <h2 class="text-xl font-semibold text-gray-800 mb-4">リアルタイム文字起こし</h2>
           <TranscriptionPanel />
@@ -32,7 +33,11 @@ onMounted(() => {
           <h2 class="text-xl font-semibold text-gray-800 mb-4">AIフィードバック</h2>
           <FeedbackPanel />
         </div>
-        <div class="md:col-span-2 mt-4">
+        <div>
+          <h2 class="text-xl font-semibold text-gray-800 mb-4">アバター</h2>
+          <AvatarView />
+        </div>
+        <div class="md:col-span-3 mt-4">
           <InterviewControls />
         </div>
       </div>

--- a/src/frontend/stores/interview.ts
+++ b/src/frontend/stores/interview.ts
@@ -24,6 +24,7 @@ let audioContext: AudioContext | null = null;
 let stream: MediaStream | null = null;
 let processor: ScriptProcessorNode | null = null;
 const SAMPLE_RATE = 16000; // バックエンドの期待値に合わせる
+const audioStream = ref<MediaStream | null>(null);
 
 export const useInterviewStore = defineStore('interview', () => {
   /**
@@ -203,6 +204,7 @@ export const useInterviewStore = defineStore('interview', () => {
     }
     try {
       stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      audioStream.value = stream;
       audioContext = new AudioContext({ sampleRate: SAMPLE_RATE });
       const source = audioContext.createMediaStreamSource(stream);
       processor = audioContext.createScriptProcessor(4096, 1, 1);
@@ -246,6 +248,7 @@ export const useInterviewStore = defineStore('interview', () => {
       processor.disconnect();
     }
     stream = null;
+    audioStream.value = null;
     audioContext = null;
     processor = null;
     console.log("🛑 音声ストリーミングを停止しました。");
@@ -312,5 +315,6 @@ export const useInterviewStore = defineStore('interview', () => {
     disconnect,
     startInterview,
     stopInterview,
+    audioStream,
   };
 }); 

--- a/src/frontend/vrm/AvatarController.ts
+++ b/src/frontend/vrm/AvatarController.ts
@@ -1,0 +1,143 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
+import {
+  VRM,
+  VRMLoaderPlugin,
+  VRMUtils,
+  VRMExpressionPresetName,
+} from '@pixiv/three-vrm';
+
+export class AvatarController {
+  private renderer: THREE.WebGLRenderer;
+  private scene: THREE.Scene;
+  private camera: THREE.PerspectiveCamera;
+  private loader: GLTFLoader;
+  private vrm?: VRM;
+  private lookAtTarget: THREE.Object3D = new THREE.Object3D();
+
+  private clock = new THREE.Clock();
+  private frameId = 0;
+
+  private audioContext?: AudioContext;
+  private analyser?: AnalyserNode;
+  private dataArray?: Uint8Array;
+
+  private blinkTimer = 0;
+  private nextBlink = 2 + Math.random() * 3;
+
+  constructor(private canvas: HTMLCanvasElement) {
+    this.renderer = new THREE.WebGLRenderer({ canvas, alpha: true });
+    this.renderer.setPixelRatio(window.devicePixelRatio);
+    this.renderer.setSize(canvas.clientWidth, canvas.clientHeight);
+
+    this.scene = new THREE.Scene();
+    this.camera = new THREE.PerspectiveCamera(
+      30,
+      canvas.clientWidth / canvas.clientHeight,
+      0.1,
+      100
+    );
+    this.camera.position.set(0, 1.3, 2.5);
+
+    this.loader = new GLTFLoader();
+    this.loader.register((parser) => new VRMLoaderPlugin(parser));
+
+    const light = new THREE.DirectionalLight(0xffffff, 1.0);
+    light.position.set(1, 1, 1);
+    this.scene.add(light);
+    this.scene.add(new THREE.AmbientLight(0xffffff, 0.5));
+
+    this.scene.add(this.lookAtTarget);
+  }
+
+  async load(url: string) {
+    const gltf = await this.loader.loadAsync(url);
+    this.vrm = gltf.userData.vrm as VRM;
+    VRMUtils.rotateVRM0(this.vrm); // モデルの向きを調整
+    this.scene.add(this.vrm.scene);
+    this.start();
+  }
+
+  private start() {
+    const loop = () => {
+      const delta = this.clock.getDelta();
+      this.update(delta);
+      this.renderer.render(this.scene, this.camera);
+      this.frameId = requestAnimationFrame(loop);
+    };
+    loop();
+  }
+
+  dispose() {
+    cancelAnimationFrame(this.frameId);
+    if (this.audioContext) {
+      this.audioContext.close();
+    }
+  }
+
+  startLipSync(stream: MediaStream) {
+    this.audioContext?.close();
+    this.audioContext = new AudioContext();
+    const source = this.audioContext.createMediaStreamSource(stream);
+    this.analyser = this.audioContext.createAnalyser();
+    this.analyser.fftSize = 1024;
+    source.connect(this.analyser);
+    this.dataArray = new Uint8Array(this.analyser.frequencyBinCount);
+  }
+
+  stopLipSync() {
+    if (this.audioContext) {
+      this.audioContext.close();
+      this.audioContext = undefined;
+      this.analyser = undefined;
+    }
+    this.setMouth(0);
+  }
+
+  private update(delta: number) {
+    if (this.vrm) {
+      this.vrm.update(delta);
+    }
+
+    this.updateLipSync();
+    this.updateBlink(delta);
+  }
+
+  private updateLipSync() {
+    if (!this.analyser || !this.dataArray) return;
+    this.analyser.getByteFrequencyData(this.dataArray);
+    let sum = 0;
+    for (let i = 0; i < this.dataArray.length; i++) {
+      sum += this.dataArray[i];
+    }
+    const volume = sum / this.dataArray.length / 255;
+    const mouth = Math.min(1, Math.max(0, volume * 2));
+    this.setMouth(mouth);
+  }
+
+  private setMouth(value: number) {
+    if (!this.vrm) return;
+    const expression = this.vrm.expressionManager;
+    if (expression) {
+      expression.setValue(VRMExpressionPresetName.A, value);
+    }
+  }
+
+  setExpression(name: VRMExpressionPresetName, value: number) {
+    if (!this.vrm) return;
+    this.vrm.expressionManager?.setValue(name, value);
+  }
+
+  private updateBlink(delta: number) {
+    if (!this.vrm) return;
+    this.blinkTimer += delta;
+    if (this.blinkTimer > this.nextBlink) {
+      this.vrm.expressionManager?.setValue(VRMExpressionPresetName.Blink, 1);
+      setTimeout(() => {
+        this.vrm?.expressionManager?.setValue(VRMExpressionPresetName.Blink, 0);
+      }, 150);
+      this.blinkTimer = 0;
+      this.nextBlink = 2 + Math.random() * 3;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `AvatarView.vue` and `AvatarController.ts` for VRM model rendering
- display avatar in `InterviewWorkspace.vue`
- expose `audioStream` in the store for lip‑sync
- include three.js and VRM libraries in dependencies

## Testing
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492a2b6c8883219768194f61736f62